### PR TITLE
SageMathCloud was renamed to CoCalc to avoid confusion

### DIFF
--- a/cloud_sagemath.md
+++ b/cloud_sagemath.md
@@ -1,30 +1,33 @@
 ---
-title: Cloud Sagemath
-program: Cloud Sagemath
+title: CoCalc
+program: CoCalc
 categories:
    - real-time-editing
    - LaTeX
    - task-list
    - pair-programming
-logo: http://www.sagemath.org/pix/sage-sticker-1x1_inch-small.png
-link: https://cloud.sagemath.com
-wlink: https://en.wikipedia.org/wiki/Sagemath
+logo: https://upload.wikimedia.org/wikipedia/en/7/72/CoCalc_Logo.png
+link: https://cocalc.com/
+wlink: https://en.wikipedia.org/wiki/CoCalc
 pros:
    - LaTeX editor (with indication of who is writing and where)
    - real-time jupyter notebooks
    - real-time terminal
-   - chat for collaborators with videoconference.
-   - ssh connection.
+   - chat for collaborators with videoconference
+   - ssh connection
    - time-travel feature for all the files
+   - snapshot-backups of all files
+   - support for teaching
+   - publish files on the web
 cons:
    - needs account to collaborate.
-opensource: https://github.com/sagemath
+opensource: https://github.com/sagemathinc/cocalc
 os:
    windows: web
    linux: web
    mac: web
 ---
 
-A cloud based environment which has a terminal, file system and more: a full scientific linux box in the cloud (R, Python, LaTeX etc...).
+A cloud based environment which has a terminal, file system and more: a full scientific linux box in the cloud (R, Python, SageMath, Julia, Octave, LaTeX etc...).
 
 It includes also helpful tools for teaching and assess students.


### PR DESCRIPTION
This basically updates the links, the logo, and mentions teaching support